### PR TITLE
Set CMP0051 to new.

### DIFF
--- a/cmake/sanitize-helpers.cmake
+++ b/cmake/sanitize-helpers.cmake
@@ -22,6 +22,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# To avoid error messages about CMP0051, this policy will be set to new. There
+# will be no problem, as TARGET_OBJECTS generator expressions will be filtered
+# with a regular expression from the sources.
+if (POLICY CMP0051)
+    cmake_policy(SET CMP0051 NEW)
+endif()
+
+
 # Helper function to get the language of a source file.
 function (sanitizer_lang_of_source FILE RETURN_VAR)
     get_filename_component(FILE_EXT "${FILE}" EXT)


### PR DESCRIPTION
To avoid error messages about CMP0051, this policy will be set to new.

This will throw a warning about CMP0011, but this has to be set only once for the whole project:

```
 CMake Warning (dev) in externals/CMake-sanitizers/cmake/FindSanitizers.cmake:
  Policy CMP0011 is not set: Included scripts do automatic cmake_policy PUSH
  and POP.  Run "cmake --help-policy CMP0011" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  The included script

   [...]/externals/CMake-sanitizers/cmake/FindSanitizers.cmake

  affects policy settings.  CMake is implying the NO_POLICY_SCOPE option for
  compatibility, so the effects are applied to the including context.
Call Stack (most recent call first):
  [...]
This warning is for project developers.  Use -Wno-dev to suppress it.
```
