### PR TITLE
Fix a couple of spelling typos

### DIFF
--- a/cmake/FindASan.cmake
+++ b/cmake/FindASan.cmake
@@ -55,5 +55,5 @@ function (add_sanitize_address TARGET)
         return()
     endif ()
 
-    saitizer_add_flags(${TARGET} "AddressSanitizer" "ASan")
+    sanitizer_add_flags(${TARGET} "AddressSanitizer" "ASan")
 endfunction ()

--- a/cmake/FindMSan.cmake
+++ b/cmake/FindMSan.cmake
@@ -53,5 +53,5 @@ function (add_sanitize_memory TARGET)
         return()
     endif ()
 
-    saitizer_add_flags(${TARGET} "MemorySanitizer" "MSan")
+    sanitizer_add_flags(${TARGET} "MemorySanitizer" "MSan")
 endfunction ()

--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -67,14 +67,14 @@ function(add_sanitizers ...)
         if (NUM_COMPILERS GREATER 1)
             message(WARNING "Can't use any sanitizers for target ${TARGET}, "
                     "because it will be compiled by incompatible compilers. "
-                    "Target will be compiled without sanitzers.")
+                    "Target will be compiled without sanitizers.")
             return()
 
         # If the target is compiled by no known compiler, ignore it.
         elseif (NUM_COMPILERS EQUAL 0)
             message(WARNING "Can't use any sanitizers for target ${TARGET}, "
                     "because it uses an unknown compiler. Target will be "
-                    "compiled without sanitzers.")
+                    "compiled without sanitizers.")
             return()
         endif ()
 

--- a/cmake/FindTSan.cmake
+++ b/cmake/FindTSan.cmake
@@ -60,5 +60,5 @@ function (add_sanitize_thread TARGET)
         return()
     endif ()
 
-    saitizer_add_flags(${TARGET} "ThreadSanitizer" "TSan")
+    sanitizer_add_flags(${TARGET} "ThreadSanitizer" "TSan")
 endfunction ()

--- a/cmake/FindUBSan.cmake
+++ b/cmake/FindUBSan.cmake
@@ -42,5 +42,5 @@ function (add_sanitize_undefined TARGET)
         return()
     endif ()
 
-    saitizer_add_flags(${TARGET} "UndefinedBehaviorSanitizer" "UBSan")
+    sanitizer_add_flags(${TARGET} "UndefinedBehaviorSanitizer" "UBSan")
 endfunction ()

--- a/cmake/sanitize-helpers.cmake
+++ b/cmake/sanitize-helpers.cmake
@@ -150,7 +150,7 @@ endfunction ()
 
 
 # Helper to assign sanitizer flags for TARGET.
-function (saitizer_add_flags TARGET NAME PREFIX)
+function (sanitizer_add_flags TARGET NAME PREFIX)
     # Get list of compilers used by target and check, if sanitizer is available
     # for this target. Other compiler checks like check for conflicting
     # compilers will be done in add_sanitizers function.


### PR DESCRIPTION
While reading the code of the macros I encountered some typo in the name of one macro
and some in comments.

No functionnal change.
Thanks for this set of macros they are very helpful.