### PR TITLE
Reenable TSan on macOS as newer Xcode toolchains support it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# out-of-source build top-level folders.
+build/
+_build/

--- a/cmake/FindTSan.cmake
+++ b/cmake/FindTSan.cmake
@@ -39,9 +39,10 @@ endif ()
 include(sanitize-helpers)
 
 if (SANITIZE_THREAD)
-    if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND
+      NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
         message(WARNING "ThreadSanitizer disabled for target ${TARGET} because "
-            "ThreadSanitizer is supported for Linux systems only.")
+          "ThreadSanitizer is supported for Linux systems and macOS only.")
         set(SANITIZE_THREAD Off CACHE BOOL
             "Enable ThreadSanitizer for sanitized targets." FORCE)
     elseif (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)


### PR DESCRIPTION
Recent Xcode toolchain have support for sanitizers: TSAN, ASAN and UBSAN. Thus, it is OK to enable adding thread sanitizer for projects on macOS.