### PR TITLE
Allow checking whether sanitizers are available

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -39,7 +39,7 @@ find_package(TSan ${FIND_QUIETLY_FLAG})
 find_package(MSan ${FIND_QUIETLY_FLAG})
 find_package(UBSan ${FIND_QUIETLY_FLAG})
 
-
+set(Sanitizers_FOUND TRUE CACHE BOOL "Sanitizers module found")
 
 
 function(sanitizer_add_blacklist_file FILE)


### PR DESCRIPTION
FindXXX packages are supposed to define a `<package name>_FOUND` variable which shall be set to `TRUE`. This is the only way to check whether `find_package` has worked gracefully (i.e., without `REQUIRED`).

Fixes #16.