### PR TITLE
Fix language detection with file names containing more than one dot

### DIFF
--- a/cmake/sanitize-helpers.cmake
+++ b/cmake/sanitize-helpers.cmake
@@ -24,7 +24,9 @@
 
 # Helper function to get the language of a source file.
 function (sanitizer_lang_of_source FILE RETURN_VAR)
-    get_filename_component(FILE_EXT "${FILE}" EXT)
+    get_filename_component(LONGEST_EXT "${FILE}" EXT)
+    # Get shortest extension as some files can have dot in their names
+    string(REGEX REPLACE "^.*(\\.[^.]+)$" "\\1" FILE_EXT ${LONGEST_EXT})
     string(TOLOWER "${FILE_EXT}" FILE_EXT)
     string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,13 +31,20 @@ function(add_testcase TESTNAME SOURCEFILES)
 
 	# add a new executable
 	add_executable(${TESTNAME} ${ARGV})
-	add_sanitizers(${TESTNAME})
 
 	# add a testcase for executable
 	add_test(${TESTNAME} ${TESTNAME})
 endfunction(add_testcase)
 
+# Function to add testcases with asan enabled.
+function(add_sanitized_testcase TESTNAME SOURCEFILES)
+	add_testcase(${TESTNAME} ${SOURCEFILES})
+	add_sanitizers(${TESTNAME})
+endfunction(add_sanitized_testcase)
 
+
+
+set(SANITIZE_ADDRESS TRUE)
 
 #
 # search for sanitizers
@@ -45,8 +52,14 @@ endfunction(add_testcase)
 find_package(Sanitizers)
 
 
-
 #
 # add testcases
 #
-add_testcase("asan_test_cpp" asan_test.cpp)
+add_sanitized_testcase("asan_test_cpp" asan_test.cpp)
+
+set_tests_properties(
+	"asan_test_cpp"
+PROPERTIES
+	WILL_FAIL TRUE
+)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,9 +56,11 @@ find_package(Sanitizers)
 # add testcases
 #
 add_sanitized_testcase("asan_test_cpp" asan_test.cpp)
+add_sanitized_testcase("shortest_ext_test_cpp" shortest.ext.test.cpp)
 
 set_tests_properties(
 	"asan_test_cpp"
+	"shortest_ext_test_cpp"
 PROPERTIES
 	WILL_FAIL TRUE
 )

--- a/tests/asan_test.cpp
+++ b/tests/asan_test.cpp
@@ -29,7 +29,8 @@ int
 main(int argc, char **argv)
 {
 	// Allocate a new array and delete it.
-	int *array = new int[argc];
+	int *array = new int[argc + 1];
+	array[argc] = 0;
 	delete[] array;
 
 	/* Access element of the deleted array. This will cause an memory error with

--- a/tests/shortest.ext.test.cpp
+++ b/tests/shortest.ext.test.cpp
@@ -1,0 +1,40 @@
+/* This file is part of CMake-sanitizers.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ * Copyright (c)
+ *  2013-2015 Matt Arsenault
+ *  2015      RWTH Aachen University, Federal Republic of Germany
+ */
+
+
+int
+main(int argc, char **argv)
+{
+	// Allocate a new array and delete it.
+	int *array = new int[argc + 1];
+	array[argc] = 0;
+	delete[] array;
+
+	/* Access element of the deleted array. This will cause an memory error with
+	 * address sanitizer.
+	 */
+	return array[argc];
+}


### PR DESCRIPTION
Some files can have multiple dots in their names but CMake always returns the longest extensions including all dots. For example generated files can have `.gen.c` longest extension.