### PR TITLE
Fix unclear error while accidentally sanitizing interface library

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -62,6 +62,13 @@ function(add_sanitizers ...)
     foreach (TARGET ${ARGV})
         # Check if this target will be compiled by exactly one compiler. Other-
         # wise sanitizers can't be used and a warning should be printed once.
+        get_target_property(TARGET_TYPE ${TARGET} TYPE)
+        if (TARGET_TYPE STREQUAL "INTERFACE_LIBRARY")
+            message(WARNING "Can't use any sanitizers for target ${TARGET}, "
+                    "because it is an interface library and cannot be "
+                    "compiled directly.")
+            return()
+        endif ()
         sanitizer_target_compilers(${TARGET} TARGET_COMPILER)
         list(LENGTH TARGET_COMPILER NUM_COMPILERS)
         if (NUM_COMPILERS GREATER 1)


### PR DESCRIPTION
Interface libraries added since CMake 3.0 version have INTERFACE_SOURCES property instead of SOURCES so it leads to error which is unclear and prevents project from compiling. Warning would be enough it this case.