### PR TITLE
handle objeclib only input for target

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -77,12 +77,12 @@ function(add_sanitizers ...)
                     "Target will be compiled without sanitizers.")
             return()
 
-        # If the target is compiled by no known compiler, ignore it.
+        # If the target is compiled by no or no known compiler, give a warning.
         elseif (NUM_COMPILERS EQUAL 0)
-            message(WARNING "Can't use any sanitizers for target ${TARGET}, "
-                    "because it uses an unknown compiler. Target will be "
-                    "compiled without sanitizers.")
-            return()
+            message(WARNING "Sanitizers for target ${TARGET} may not be"
+                    " usable, because it uses no or an unknown compiler. "
+                    "This is a false warning for targets using only "
+		    "object lib(s) as input.")
         endif ()
 
         # Add sanitizers for target.


### PR DESCRIPTION
do not fail on zero compilers as this can also happen if a target has only objectlib as input.