### PR TITLE
Define ASan_SHARED_LIB that may be used without ASan_WRAPPER

### DIFF
--- a/cmake/FindASan.cmake
+++ b/cmake/FindASan.cmake
@@ -47,7 +47,11 @@ if (SANITIZE_ADDRESS)
         "ASan")
 
     find_program(ASan_WRAPPER "asan-wrapper" PATHS ${CMAKE_MODULE_PATH})
-	mark_as_advanced(ASan_WRAPPER)
+    mark_as_advanced(ASan_WRAPPER)
+    if (CMAKE_SYSTEM_NAME EQUAL "Linux")	
+       find_library(ASan_SHARED_LIB "clang_rt.asan-x86_64" PATH_SUFFIXES "linux")
+       mark_as_advanced(ASan_SHARED_LIB)
+    endif()
 endif ()
 
 function (add_sanitize_address TARGET)


### PR DESCRIPTION
In some cases I'd like to be able to use ASan without the ASan wrapper, in this case I need to have access to ASan_SHARED_LIB in order to properly LD_PRELOAD it as the asan-wrapper does.