### PR TITLE
Bump CMake minimum required version 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@
 #
 
 # minimum required cmake version
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # project name
 project("CMake-sanitizers")


### PR DESCRIPTION
CMake older than 2.8.12 is deprecated in CMake 3.20. This patch fixes deprecation warnings in latest CMake versions