### PR TITLE
Update cmake api calls for Ubuntu Focal proper operation.

### DIFF
--- a/cmake/FindASan.cmake
+++ b/cmake/FindASan.cmake
@@ -25,6 +25,9 @@
 option(SANITIZE_ADDRESS "Enable AddressSanitizer for sanitized targets." Off)
 
 set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=address"
+
     # Clang 3.2+ use this version. The no-omit-frame-pointer option is optional.
     "-g -fsanitize=address -fno-omit-frame-pointer"
     "-g -fsanitize=address"

--- a/cmake/FindMSan.cmake
+++ b/cmake/FindMSan.cmake
@@ -25,6 +25,9 @@
 option(SANITIZE_MEMORY "Enable MemorySanitizer for sanitized targets." Off)
 
 set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=memory"
+    # GNU/Clang
     "-g -fsanitize=memory"
 )
 

--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -26,8 +26,8 @@
 # link against the sanitizers.
 option(SANITIZE_LINK_STATIC "Try to link static against sanitizers." Off)
 
-
-
+# Highlight this module has been loaded.
+set(Sanitizers_FOUND TRUE)
 
 set(FIND_QUIETLY_FLAG "")
 if (DEFINED Sanitizers_FIND_QUIETLY)
@@ -38,9 +38,6 @@ find_package(ASan ${FIND_QUIETLY_FLAG})
 find_package(TSan ${FIND_QUIETLY_FLAG})
 find_package(MSan ${FIND_QUIETLY_FLAG})
 find_package(UBSan ${FIND_QUIETLY_FLAG})
-
-
-
 
 function(sanitizer_add_blacklist_file FILE)
     if(NOT IS_ABSOLUTE ${FILE})

--- a/cmake/FindTSan.cmake
+++ b/cmake/FindTSan.cmake
@@ -25,6 +25,9 @@
 option(SANITIZE_THREAD "Enable ThreadSanitizer for sanitized targets." Off)
 
 set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=thread"
+    # GNU/Clang
     "-g -fsanitize=thread"
 )
 

--- a/cmake/FindUBSan.cmake
+++ b/cmake/FindUBSan.cmake
@@ -26,6 +26,9 @@ option(SANITIZE_UNDEFINED
     "Enable UndefinedBehaviorSanitizer for sanitized targets." Off)
 
 set(FLAG_CANDIDATES
+    # MSVC uses
+    "/fsanitize=undefined"
+    # GNU/Clang
     "-g -fsanitize=undefined"
 )
 

--- a/cmake/sanitize-helpers.cmake
+++ b/cmake/sanitize-helpers.cmake
@@ -75,6 +75,7 @@ endfunction ()
 
 # Helper function to check compiler flags for language compiler.
 function (sanitizer_check_compiler_flag FLAG LANG VARIABLE)
+
     if (${LANG} STREQUAL "C")
         include(CheckCCompilerFlag)
         check_c_compiler_flag("${FLAG}" ${VARIABLE})
@@ -97,6 +98,7 @@ function (sanitizer_check_compiler_flag FLAG LANG VARIABLE)
                 " - Failed (Check not supported)")
         endif ()
     endif()
+
 endfunction ()
 
 
@@ -167,11 +169,10 @@ function (sanitizer_add_flags TARGET NAME PREFIX)
         return()
     endif()
 
-    # Set compile- and link-flags for target.
-    set_property(TARGET ${TARGET} APPEND_STRING
-        PROPERTY COMPILE_FLAGS " ${${PREFIX}_${TARGET_COMPILER}_FLAGS}")
-    set_property(TARGET ${TARGET} APPEND_STRING
-        PROPERTY COMPILE_FLAGS " ${SanBlist_${TARGET_COMPILER}_FLAGS}")
-    set_property(TARGET ${TARGET} APPEND_STRING
-        PROPERTY LINK_FLAGS " ${${PREFIX}_${TARGET_COMPILER}_FLAGS}")
+    separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS} ${SanBlist_${TARGET_COMPILER}_FLAGS}")
+    target_compile_options(${TARGET} PRIVATE ${flags_list})
+
+    separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS}")
+    target_link_options(${TARGET} PRIVATE ${flags_list})
+
 endfunction ()

--- a/cmake/sanitize-helpers.cmake
+++ b/cmake/sanitize-helpers.cmake
@@ -112,7 +112,7 @@ function (sanitizer_check_compiler_flags FLAG_CANDIDATES NAME PREFIX)
         # So instead of searching flags foreach language, search flags foreach
         # compiler used.
         set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})
-        if (NOT DEFINED ${PREFIX}_${COMPILER}_FLAGS)
+        if (COMPILER AND NOT DEFINED ${PREFIX}_${COMPILER}_FLAGS)
             foreach (FLAG ${FLAG_CANDIDATES})
                 if(NOT CMAKE_REQUIRED_QUIET)
                     message(STATUS "Try ${COMPILER} ${NAME} flag = [${FLAG}]")

--- a/cmake/sanitize-helpers.cmake
+++ b/cmake/sanitize-helpers.cmake
@@ -170,9 +170,9 @@ function (sanitizer_add_flags TARGET NAME PREFIX)
     endif()
 
     separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS} ${SanBlist_${TARGET_COMPILER}_FLAGS}")
-    target_compile_options(${TARGET} PRIVATE ${flags_list})
+    target_compile_options(${TARGET} PUBLIC ${flags_list})
 
     separate_arguments(flags_list UNIX_COMMAND "${${PREFIX}_${TARGET_COMPILER}_FLAGS}")
-    target_link_options(${TARGET} PRIVATE ${flags_list})
+    target_link_options(${TARGET} PUBLIC ${flags_list})
 
 endfunction ()


### PR DESCRIPTION
The first commit introduces the changes required for proper works on CMake 3.11 distributed via apt in Ubuntu Focal.
The second commit introduces the `Sanitizers_FOUND` variable mandatory on CMake modules. This variable can be used to include sanitizer function calls only if the Sanitizer module is present as:

```cmake
  if(Sanitizers_FOUND)
    add_sanitize_thread(<target name>)
  endif()
```