### PR TITLE
README.md: update sanitizers-cmake submodule repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ CMake module to enable sanitizers for binary targets.
 To use [FindSanitizers.cmake](cmake/FindSanitizers.cmake), simply add this repository as git submodule into your own repository
 ```Shell
 mkdir externals
-git submodule add git://github.com/arsenm/sanitizers-cmake.git externals/sanitizers-cmake
+git submodule add git@github.com:arsenm/sanitizers-cmake.git externals/sanitizers-cmake
 ```
 and adding ```externals/sanitizers-cmake/cmake``` to your ```CMAKE_MODULE_PATH```
 ```CMake


### PR DESCRIPTION
When I clone `sanitizers-cmake` repo into my project according to [Include into your project](https://github.com/arsenm/sanitizers-cmake/blob/master/README.md#include-into-your-project) , it seems fail until type `ctrl + c`, the result in my terminal as follows:
```
➜  /Users/junbozheng/san git:(master) time git submodule add git://github.com/arsenm/sanitizers-cmake.git externals/sanitizers-cmake
Cloning into '/Users/junbozheng/san/externals/sanitizers-cmake'...
^C
git submodule add git://github.com/arsenm/sanitizers-cmake.git   0.18s user 0.20s system 0% cpu 49.989 total
```

Then, I checked the `sanitizers-cmake` submodule repo link and update it, I try again, and it seems fine to me.
```
➜  /Users/junbozheng/san git:(master) time git submodule add git@github.com:arsenm/sanitizers-cmake.git externals/sanitizers-cmake
Cloning into '/Users/junbozheng/san/externals/sanitizers-cmake'...
remote: Enumerating objects: 214, done.
remote: Total 214 (delta 0), reused 0 (delta 0), pack-reused 214
Receiving objects: 100% (214/214), 47.66 KiB | 208.00 KiB/s, done.
Resolving deltas: 100% (137/137), done.
git submodule add git@github.com:arsenm/sanitizers-cmake.git   0.26s user 0.32s system 10% cpu 5.320 total
➜  /Users/junbozheng/san git:(master) ✗ ..
```

Signed-off-by: Junbo Zheng <3273070@qq.com>