### PR TITLE
Address cmake-lint errors in FindSanitizers.cmake

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -49,7 +49,7 @@ function(sanitizer_add_blacklist_file FILE)
         "SanitizerBlacklist" "SanBlist")
 endfunction()
 
-function(add_sanitizers ...)
+function(add_sanitizers)
     # If no sanitizer is enabled, return immediately.
     if (NOT (SANITIZE_ADDRESS OR SANITIZE_MEMORY OR SANITIZE_THREAD OR
         SANITIZE_UNDEFINED))
@@ -74,12 +74,12 @@ function(add_sanitizers ...)
                     "Target will be compiled without sanitizers.")
             return()
 
-        # If the target is compiled by no or no known compiler, give a warning.
         elseif (NUM_COMPILERS EQUAL 0)
+            # If the target is compiled by no known compiler, give a warning.
             message(WARNING "Sanitizers for target ${TARGET} may not be"
                     " usable, because it uses no or an unknown compiler. "
                     "This is a false warning for targets using only "
-		    "object lib(s) as input.")
+                    "object lib(s) as input.")
         endif ()
 
         # Add sanitizers for target.
@@ -87,5 +87,5 @@ function(add_sanitizers ...)
         add_sanitize_thread(${TARGET})
         add_sanitize_memory(${TARGET})
         add_sanitize_undefined(${TARGET})
-	endforeach ()
+    endforeach ()
 endfunction(add_sanitizers)


### PR DESCRIPTION
Runnging cmake-lint on some ci builds and it included some errors in the FindSanitizers file.

```
    $ cmake-lint --version
    0.6.13

    $ cmake-lint --tab-size 4 build/FindSanitizers.cmake
    ... snip snip ...
    build/FindSanitizers.cmake:52,24: [E0109] Invalid argument name ...
        in function/macro definition
    build/FindSanitizers.cmake:82,00: [C0306] Tab-policy violation.
        Found tab but should be space
    build/FindSanitizers.cmake:90,00: [C0306] Tab-policy violation.
        Found tab but should be space
    build/FindSanitizers.cmake:77,08: [C0307] Bad indentation:
        # If the target is compiled by no or no known compiler, give a warning.
            ^----BodyNode: 1:0->FlowControlNode: 52:0->BodyNode:
                           52:24->FlowControlNode: 59:4->BodyNode:
                           59:28->IfBlockNode: 71:8->BodyNode:
                           71:36->CommentNode: 77:8
```

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>