### PR TITLE
Add minimum required CMake version

### DIFF
--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -22,6 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+cmake_minimum_required(VERSION 3.13)	# target_link_options()
+
 # If any of the used compiler is a GNU compiler, add a second option to static
 # link against the sanitizers.
 option(SANITIZE_LINK_STATIC "Try to link static against sanitizers." Off)


### PR DESCRIPTION
You get an error message like this (from CMake 3.7) if you try to use sanitizers-cmake with CMake versions less than 3.13:

    CMake Error at cmake/sanitizers/cmake/sanitize-helpers.cmake:176 (target_link_options):
      Unknown CMake command "target_link_options".
    Call Stack (most recent call first):
      cmake/sanitizers/cmake/FindASan.cmake:61 (sanitizer_add_flags)
      cmake/sanitizers/cmake/FindSanitizers.cmake:94 (add_sanitize_address)
      cmake/sanitizers/cmake/FindSanitizers.cmake:107 (add_sanitizers)
      CMakeLists.txt:52 (add_sanitizers_per_dir_targets)

References: #33
Fixes: ef2848366f7e ("Update cmake api calls for Ubuntu Focal proper opertion.")