### PR TITLE
Only build tests when we are the top level project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,5 +47,9 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 #
 # add tests
 #
-enable_testing()
-add_subdirectory(tests)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+	include(CTest)
+	if(BUILD_TESTING)
+		add_subdirectory(tests)
+	endif()
+endif()


### PR DESCRIPTION
sanitizers-cmake tests are being run when included as a sub-project.

Change Summary: When sanitizers-cmake is the top level project its tests will run by default. The can be turned off with "-DBUILD_TESTING=OFF". When sanitizers-cmake is not the top level project, its test will not run.

Added change as described in "[An Introduction to Modern CMake](https://cliutils.gitlab.io/modern-cmake/chapters/testing.html)"  to only include tests when we are the top level project, as determined by [CMAKE_PROJECT_NAME](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_NAME.html) .

Use of Ctest defines cmake option BUILD_TESTING so users can turn testing on an off (defaults to ON, the same as the current sanitizers-cmake implementation). Note CTest calls enable_testing().

