### PR TITLE
Update minimum required cmake version to a range to fix cmake depreca…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@
 #
 
 # minimum required cmake version
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...3.10)
 
 # project name
 project("CMake-sanitizers")


### PR DESCRIPTION
…tion error and warning

CMake 4.0 has removed support for versions of cmake older than 3.5.  See [CMake 4.0 Release Notes](https://cmake.org/cmake/help/latest/release/4.0.html).

When building sanitizers-cmake with newer cmake version (version 4.1.2 tested), the following error message is output, breaking compilation.

```
CMake Error at CMakeLists.txt:33 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
Updating  cmake_minimum_required VERSION to a range with max version 3.5 still produces a deprecation warning:

```
CMake Deprecation Warning at CMakeLists.txt:33 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/damien/work/src/sanitizers-cmake/build
```

Therefore I have updated the maximum of the minimum version range to 3.10.

Tested with cmake version 4.1.2:
```
damien@harvest ~/work/src/sanitizers-cmake $ cmake -S . -B build
-- The C compiler identification is GNU 14.3.1
-- The CXX compiler identification is GNU 14.3.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Try GNU AddressSanitizer flag = [/fsanitize=address]
-- Performing Test ASan_FLAG_DETECTED
-- Performing Test ASan_FLAG_DETECTED - Failed
-- Try GNU AddressSanitizer flag = [-g -fsanitize=address -fno-omit-frame-pointer]
-- Performing Test ASan_FLAG_DETECTED
-- Performing Test ASan_FLAG_DETECTED - Success
-- Configuring done (1.1s)
-- Generating done (0.0s)
-- Build files have been written to: /home/damien/work/src/sanitizers-cmake/build
damien@harvest ~/work/src/sanitizers-cmake $ cmake --build build
[ 25%] Building CXX object tests/CMakeFiles/asan_test_cpp.dir/asan_test.cpp.o
[ 50%] Linking CXX executable asan_test_cpp
[ 50%] Built target asan_test_cpp
[ 75%] Building CXX object tests/CMakeFiles/shortest_ext_test_cpp.dir/shortest.ext.test.cpp.o
[100%] Linking CXX executable shortest_ext_test_cpp
[100%] Built target shortest_ext_test_cpp
```